### PR TITLE
everything

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing
+
+Note: __README.md__ is generated from comments in __index.js__. Do not modify
+__README.md__ directly.
+
+1.  Update local master branch:
+
+        $ git checkout master
+        $ git pull upstream master
+
+2.  Create feature branch:
+
+        $ git checkout -b feature-x
+
+3.  Make one or more atomic commits, and ensure that each commit has a
+    descriptive commit message. Commit messages should be line wrapped
+    at 72 characters.
+
+4.  Run `make lint test`, and address any errors. Preferably, fix commits
+    in place using `git rebase` or `git commit --amend` to make the changes
+    easier to review.
+
+5.  Push:
+
+        $ git push origin feature-x
+
+6.  Open a pull request.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Sanctuary
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,53 @@
+ESLINT = node_modules/.bin/eslint --config node_modules/sanctuary-style/eslint-es3.json --env es3
+MOCHA = node_modules/.bin/mocha --reporter dot --ui tdd
+NPM = npm
+REMEMBER_BOWER = node_modules/.bin/remember-bower
+TRANSCRIBE = node_modules/.bin/transcribe
+XYZ = node_modules/.bin/xyz --repo git@github.com:sanctuary-js/sanctuary-type-identifiers.git --script scripts/prepublish
+
+
+.PHONY: all
+all: LICENSE README.md
+
+.PHONY: LICENSE
+LICENSE:
+	cp -- '$@' '$@.orig'
+	sed 's/Copyright (c) .* Sanctuary/Copyright (c) $(shell git log --date=format:%Y --pretty=format:%ad | sort -r | head -n 1) Sanctuary/' '$@.orig' >'$@'
+	rm -- '$@.orig'
+
+README.md: index.js
+	$(TRANSCRIBE) \
+	  --heading-level 4 \
+	  --url 'https://github.com/sanctuary-js/sanctuary-type-identifiers/blob/v$(VERSION)/{filename}#L{line}' \
+	  -- $^ \
+	| LC_ALL=C sed 's/<h4 name="\(.*\)#\(.*\)">\(.*\)\1#\2/<h4 name="\1.prototype.\2">\3\1#\2/' >'$@'
+
+
+.PHONY: lint
+lint:
+	$(ESLINT) \
+	  --global define \
+	  --global module \
+	  --global self \
+	  -- index.js
+	$(ESLINT) \
+	  --env node \
+	  --global suite \
+	  --global test \
+	  -- test/index.js
+	$(REMEMBER_BOWER) $(shell pwd)
+
+
+.PHONY: release-major release-minor release-patch
+release-major release-minor release-patch:
+	@$(XYZ) --increment $(@:release-%=%)
+
+
+.PHONY: setup
+setup:
+	$(NPM) install
+
+
+.PHONY: test
+test:
+	$(MOCHA) -- test/index.js

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,32 @@
+{
+  "name": "sanctuary-type-identifiers",
+  "description": "Specification for type identifiers",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/sanctuary-js/sanctuary-type-identifiers.git"
+  },
+  "main": "index.js",
+  "moduleType": [
+    "amd",
+    "globals",
+    "node"
+  ],
+  "keywords": [
+    "sanctuary",
+    "types"
+  ],
+  "dependencies": {},
+  "ignore": [
+    "/.git/",
+    "/bower_components/",
+    "/node_modules/",
+    "/scripts/",
+    "/test/",
+    "/.*",
+    "/CONTRIBUTING.md",
+    "/Makefile",
+    "/circle.yml",
+    "/package.json"
+  ]
+}

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,16 @@
+dependencies:
+  override:
+    - printf '%s\n' color=false progress=false >.npmrc
+    - rm -rf node_modules
+    - case $CIRCLE_NODE_INDEX in 0) make setup ;; 1) nvm exec 4 make setup ;; 2) nvm install 6 && nvm exec 6 make setup ;; esac:
+        parallel: true
+
+machine:
+  node:
+    version: 0.12.7
+
+test:
+  override:
+    - make lint
+    - case $CIRCLE_NODE_INDEX in 0) make test ;; 1) nvm exec 4 make test ;; 2) nvm exec 6 make test ;; esac:
+        parallel: true

--- a/index.js
+++ b/index.js
@@ -1,0 +1,134 @@
+/*
+        @@@@@@@            @@@@@@@         @@
+      @@       @@        @@       @@      @@@
+    @@   @@@ @@  @@    @@   @@@ @@  @@   @@@@@@ @@   @@@  @@ @@@      @@@@
+   @@  @@   @@@   @@  @@  @@   @@@   @@   @@@   @@   @@@  @@@   @@  @@@   @@
+   @@  @@   @@@   @@  @@  @@   @@@   @@   @@@   @@   @@@  @@@   @@  @@@@@@@@
+   @@  @@   @@@  @@   @@  @@   @@@  @@    @@@   @@   @@@  @@@   @@  @@@
+    @@   @@@ @@@@@     @@   @@@ @@@@@      @@@    @@@ @@  @@@@@@      @@@@@
+      @@                 @@                           @@  @@
+        @@@@@@@            @@@@@@@               @@@@@    @@
+                                                          */
+//. # sanctuary-type-identifiers
+//.
+//. A type is a set of values. Boolean, for example, is the type comprising
+//. `true` and `false`. A value may be a member of multiple types (`42` is a
+//. member of Number, PositiveNumber, Integer, and many other types).
+//.
+//. In certain situations it is useful to divide JavaScript values into
+//. non-overlapping types. The language provides two constructs for this
+//. purpose: the [`typeof`][1] operator and [`Object.prototype.toString`][2].
+//. Each has pros and cons, but neither supports user-defined types.
+//.
+//. This package specifies an [algorithm][3] for deriving a _type identifier_
+//. from any JavaScript value, and exports an implementation of the algorithm.
+//. Authors of algebraic data types may follow this specification in order to
+//. make their data types compatible with the algorithm.
+//.
+//. ### Algorithm
+//.
+//. 1.  Take any JavaScript value `x`.
+//.
+//. 2.  If `x` is `null` or `undefined`, go to step 6.
+//.
+//. 3.  If `x.constructor` evaluates to `null` or `undefined`, go to step 6.
+//.
+//. 4.  If `x.constructor.prototype === x`, go to step 6. This check prevents a
+//.     prototype object from being considered a member of its associated type.
+//.
+//. 5.  If `typeof x.constructor['@@type']` evaluates to `'string'`, return
+//.     the value of `x.constructor['@@type']`.
+//.
+//. 6.  Return the [`Object.prototype.toString`][2] representation of `x`
+//.     without the leading `'[object '` and trailing `']'`.
+//.
+//. ### Compatibility
+//.
+//. For an algebraic data type to be compatible with the [algorithm][3]:
+//.
+//.   - every member of the type must have a `constructor` property pointing
+//.     to an object known as the _type representative_;
+//.
+//.   - the type representative must have a `@@type` property; and
+//.
+//.   - the type representative's `@@type` property (the _type identifier_)
+//.     must be a string primitive, ideally `'<npm-package-name>/<type-name>'`.
+//.
+//. For example:
+//.
+//. ```javascript
+//. //  Identity :: a -> Identity a
+//. function Identity(x) {
+//.   if (!(this instanceof Identity)) return new Identity(x);
+//.   this.value = x;
+//. }
+//.
+//. Identity['@@type'] = 'my-package/Identity';
+//. ```
+//.
+//. Note that by using a constructor function the `constructor` property is set
+//. implicitly for each value created. Constructor functions are convenient for
+//. this reason, but are not required. This definition is also valid:
+//.
+//. ```javascript
+//. //  IdentityTypeRep :: TypeRep Identity
+//. var IdentityTypeRep = {
+//.   '@@type': 'my-package/Identity'
+//. };
+//.
+//. //  Identity :: a -> Identity a
+//. function Identity(x) {
+//.   return {constructor: IdentityTypeRep, value: x};
+//. }
+//. ```
+//.
+//. ### Usage
+//.
+//. ```javascript
+//. var Identity = require('my-package').Identity;
+//. var type = require('sanctuary-type-identifiers');
+//.
+//. type(null);         // => 'Null'
+//. type(true);         // => 'Boolean'
+//. type([1, 2, 3]);    // => 'Array'
+//. type(Identity);     // => 'Function'
+//. type(Identity(0));  // => 'my-package/Identity'
+//. ```
+//.
+//.
+//. [1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof
+//. [2]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toString
+//. [3]: #algorithm
+
+(function(f) {
+
+  'use strict';
+
+  if (typeof module === 'object' && typeof module.exports === 'object') {
+    module.exports = f();
+  } else if (typeof define === 'function' && define.amd != null) {
+    define([], f);
+  } else {
+    self.sanctuaryTypeIdentifiers = f();
+  }
+
+}(function() {
+
+  'use strict';
+
+  //  $$type :: String
+  var $$type = '@@type';
+
+  //  type :: Any -> String
+  function type(x) {
+    return x != null &&
+           x.constructor != null &&
+           x.constructor.prototype !== x &&
+           typeof x.constructor[$$type] === 'string' ?
+      x.constructor[$$type] :
+      Object.prototype.toString.call(x).slice('[object '.length, -']'.length);
+  }
+
+  return type;
+
+}));

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "sanctuary-type-identifiers",
+  "version": "0.0.0",
+  "description": "Specification for type identifiers",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/sanctuary-js/sanctuary-type-identifiers.git"
+  },
+  "scripts": {
+    "test": "make lint test"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "eslint": "2.9.x",
+    "mocha": "3.2.x",
+    "remember-bower": "0.1.x",
+    "sanctuary-style": "0.4.x",
+    "sanctuary-type-classes": "1.3.x",
+    "transcribe": "0.5.x",
+    "xyz": "2.0.x"
+  },
+  "files": [
+    "/LICENSE",
+    "/README.md",
+    "/index.js",
+    "/package.json"
+  ]
+}

--- a/scripts/prepublish
+++ b/scripts/prepublish
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+rm -f README.md
+make
+git add LICENSE README.md

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,57 @@
+'use strict';
+
+var assert = require('assert');
+
+var Z = require('sanctuary-type-classes');
+
+var type = require('..');
+
+
+function eq(actual, expected) {
+  assert.strictEqual(arguments.length, eq.length);
+  assert.strictEqual(Z.toString(actual), Z.toString(expected));
+  assert.strictEqual(Z.equals(actual, expected), true);
+}
+
+
+//  Identity :: a -> Identity a
+function Identity(x) {
+  if (!(this instanceof Identity)) return new Identity(x);
+  this.value = x;
+}
+
+Identity['@@type'] = 'my-package/Identity';
+
+
+var MaybeTypeRep = {'@@type': 'my-package/Maybe'};
+
+//  Nothing :: Maybe a
+var Nothing = {constructor: MaybeTypeRep, isNothing: true, isJust: false};
+
+//  Just :: a -> Maybe a
+function Just(x) {
+  return {constructor: MaybeTypeRep, isNothing: false, isJust: true, value: x};
+}
+
+
+test('type', function() {
+  eq(type(null), 'Null');
+  eq(type(undefined), 'Undefined');
+  eq(type({constructor: null}), 'Object');
+  eq(type({constructor: {'@@type': null}}), 'Object');
+  eq(type({constructor: {'@@type': new String('')}}), 'Object');
+  eq(type(Identity(42)), 'my-package/Identity');
+  eq(type(Identity), 'Function');
+  eq(type(Identity.prototype), 'Object');
+  eq(type(Nothing), 'my-package/Maybe');
+  eq(type(Just(0)), 'my-package/Maybe');
+  eq(type(Nothing.constructor), 'Object');
+
+  eq(type(false), 'Boolean');
+  eq(type(0), 'Number');
+  eq(type(''), 'String');
+
+  eq(type(new Boolean(false)), 'Boolean');
+  eq(type(new Number(0)), 'Number');
+  eq(type(new String('')), 'String');
+});


### PR DESCRIPTION
In sanctuary-js/sanctuary-type-classes#22 we decided to move the `@@type` property from the values themselves to their type representatives. This drew attention to the fact that `type :: Any -> String` is currently defined in three projects: sanctuary, sanctuary-def, and sanctuary-type-classes. It would be nice to remove this duplication. Furthermore, dedicating a project to type identifiers will hopefully convey why they are useful and encourage authors of algebraic data types to adopt the convention (as @Avaq has done with Fluture).

The implementation itself is just a few lines of code.
