### PR TITLE
use [\s\S] rather than [^] for Internet Explorer compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,13 +106,13 @@
   //  pattern :: RegExp
   var pattern = new RegExp(
     '^'
-  + '([^]+)'      //  <namespace>
-  + '/'           //  SOLIDUS (U+002F)
-  + '([^]+?)'     //  <name>
-  + '(?:'         //  optional non-capturing group {
-  +   '@'         //    COMMERCIAL AT (U+0040)
-  +   '([0-9]+)'  //    <version>
-  + ')?'          //  }
+  + '([\\s\\S]+)'   //  <namespace>
+  + '/'             //  SOLIDUS (U+002F)
+  + '([\\s\\S]+?)'  //  <name>
+  + '(?:'           //  optional non-capturing group {
+  +   '@'           //    COMMERCIAL AT (U+0040)
+  +   '([0-9]+)'    //    <version>
+  + ')?'            //  }
   + '$'
   );
 


### PR DESCRIPTION
It seems `[^]` does not work correctly in IE10, causing test failures in sanctuary-js/sanctuary#399. For some reason `pattern.exec('sanctuary/Either').slice(1)` gives `['', '', undefined]` rather than `['sanctuary', 'Either', undefined]`.

_JavaScript: Learn something cool one day; learn that it doesn't work in IE the next._

Yet again your browser tests have proven useful, @Shard!
