### PR TITLE
move type identifiers from type representatives to members

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
   "overrides": [
     {
       "files": ["*.md"],
-      "globals": {"Identity": false, "type": false},
+      "globals": {"Identity": false, "show": false, "type": false},
       "rules": {
         "no-extra-semi": ["off"],
         "no-unused-vars": ["error", {"varsIgnorePattern": "^(Identity|type)$"}]

--- a/index.js
+++ b/index.js
@@ -31,10 +31,7 @@
 //.
 //. For a type to be compatible with the algorithm:
 //.
-//.   - every member of the type MUST have a `constructor` property
-//.     pointing to an object known as the _type representative_;
-//.
-//.   - the type representative MUST have a `@@type` property
+//.   - every member of the type MUST have a `@@type` property
 //.     (the _type identifier_); and
 //.
 //.   - the type identifier MUST be a string primitive and SHOULD have
@@ -55,34 +52,6 @@
 //. _namespace_ will be `null` and _version_ will be `0`.
 //.
 //. If the _version_ is not given, it is assumed to be `0`.
-//.
-//. For example:
-//.
-//. ```javascript
-//. //  Identity :: a -> Identity a
-//. function Identity(x) {
-//.   if (!(this instanceof Identity)) return new Identity (x);
-//.   this.value = x;
-//. }
-//.
-//. Identity['@@type'] = 'my-package/Identity';
-//. ```
-//.
-//. Note that by using a constructor function the `constructor` property is set
-//. implicitly for each value created. Constructor functions are convenient for
-//. this reason, but are not required. This definition is also valid:
-//.
-//. ```javascript
-//. //  IdentityTypeRep :: TypeRep Identity
-//. var IdentityTypeRep = {
-//.   '@@type': 'my-package/Identity'
-//. };
-//.
-//. //  Identity :: a -> Identity a
-//. function Identity(x) {
-//.   return {constructor: IdentityTypeRep, value: x};
-//. }
-//. ```
 
 (function(f) {
 
@@ -124,11 +93,18 @@
   //. ```
   //.
   //. ```javascript
-  //. > function Identity(x) {
-  //. .   if (!(this instanceof Identity)) return new Identity (x);
-  //. .   this.value = x;
+  //. > const Identity$prototype = {
+  //. .   '@@type': 'my-package/Identity@1',
+  //. .   '@@show': function() {
+  //. .     return 'Identity (' + show (this.value) + ')';
+  //. .   }
   //. . }
-  //. . Identity['@@type'] = 'my-package/Identity@1';
+  //.
+  //. > const Identity = value =>
+  //. .   Object.assign (Object.create (Identity$prototype), {value})
+  //.
+  //. > type (Identity (0))
+  //. 'my-package/Identity@1'
   //.
   //. > type.parse (type (Identity (0)))
   //. {namespace: 'my-package', name: 'Identity', version: 1}
@@ -156,8 +132,8 @@
     return x != null &&
            x.constructor != null &&
            x.constructor.prototype !== x &&
-           typeof x.constructor[$$type] === 'string' ?
-      x.constructor[$$type] :
+           typeof x[$$type] === 'string' ?
+      x[$$type] :
       (Object.prototype.toString.call (x)).slice ('[object '.length,
                                                   -']'.length);
   }
@@ -174,7 +150,7 @@
   //. > type.parse ('nonsense!')
   //. {namespace: null, name: 'nonsense!', version: 0}
   //.
-  //. > type.parse (Identity['@@type'])
+  //. > type.parse (type (Identity (0)))
   //. {namespace: 'my-package', name: 'Identity', version: 1}
   //. ```
   type.parse = function parse(s) {

--- a/test/index.js
+++ b/test/index.js
@@ -21,17 +21,26 @@ function Identity(x) {
   this.value = x;
 }
 
-Identity['@@type'] = 'my-package/Identity';
+Identity.prototype['@@type'] = 'my-package/Identity';
 
 
-var MaybeTypeRep = {'@@type': 'my-package/Maybe'};
+var maybeTypeIdent = 'my-package/Maybe';
 
 //  Nothing :: Maybe a
-var Nothing = {constructor: MaybeTypeRep, isNothing: true, isJust: false};
+var Nothing = {
+  '@@type': maybeTypeIdent,
+  'isNothing': true,
+  'isJust': false
+};
 
 //  Just :: a -> Maybe a
 function Just(x) {
-  return {constructor: MaybeTypeRep, isNothing: false, isJust: true, value: x};
+  return {
+    '@@type': maybeTypeIdent,
+    'isNothing': false,
+    'isJust': true,
+    'value': x
+  };
 }
 
 function TypeIdentifier(namespace, name, version) {
@@ -50,7 +59,7 @@ test ('type', function() {
   eq (type (Identity.prototype), 'Object');
   eq (type (Nothing), 'my-package/Maybe');
   eq (type (Just (0)), 'my-package/Maybe');
-  eq (type (Nothing.constructor), 'Object');
+  eq (type (Nothing.constructor), 'Function');
 
   eq (type (false), 'Boolean');
   eq (type (0), 'Number');


### PR DESCRIPTION
This specification currently reuses the [type representatives][1] defined in the Fantasy Land specification. In fantasyland/fantasy-land#315 I have proposed changing the property name from `'constructor'` to `'fantasy-land'`. The proposal is likely to be accepted, at which point members of algebraic data types would need two different “type representatives” to be compatible with both specifications.

A type identifier need not be defined on a type representative; attaching it to each member would work equally well. This pull request removes all references to type representatives, disentangling this specification from the Fantasy Land specification.


[1]: https://github.com/fantasyland/fantasy-land/tree/v4.0.1#type-representatives
