### PR TITLE
eslint: use "readonly" for globals in place of deprecated value

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
   "overrides": [
     {
       "files": ["*.md"],
-      "globals": {"Identity": false, "show": false, "type": false},
+      "globals": {"Identity": "readonly", "show": "readonly", "type": "readonly"},
       "rules": {
         "no-unused-vars": ["error", {"varsIgnorePattern": "^type$"}]
       }


### PR DESCRIPTION
Relates to sanctuary-js/sanctuary-style#33
