### PR TITLE
use `s` flag to improve readability of regular expression

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,14 +61,15 @@ const $$type = '@@type';
 //  pattern :: RegExp
 const pattern = new RegExp (
   '^'
-+ '([\\s\\S]+)'   //  <namespace>
++ '(.+)'          //  <namespace>
 + '/'             //  SOLIDUS (U+002F)
-+ '([\\s\\S]+?)'  //  <name>
++ '(.+?)'         //  <name>
 + '(?:'           //  optional non-capturing group {
 +   '@'           //    COMMERCIAL AT (U+0040)
 +   '([0-9]+)'    //    <version>
 + ')?'            //  }
-+ '$'
++ '$',
+  's'
 );
 
 //. ### Usage


### PR DESCRIPTION
Strictly speaking this is a breaking change as there could exist a runtime that supports all the other features we use but not [`RegExp.prototype.dotAll`][1].


[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/dotAll
