### PR TITLE
use relative import specifier

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,7 @@ import {deepStrictEqual as eq} from 'node:assert';
 
 import test from 'oletus';
 
-import {identifierOf, parseIdentifier} from 'sanctuary-type-identifiers';
+import {identifierOf, parseIdentifier} from '../index.js';
 
 
 //  Identity :: a -> Identity a


### PR DESCRIPTION
<https://nodejs.org/api/packages.html#self-referencing-a-package-using-its-name>:

> Within a package, the values defined in the package's `package.json` [`"exports"`][1] field can be referenced via the package's name.

Using this feature seemed like a good idea at the time, but I have since discovered that it is not foolproof: if a package indirectly depends on (an older version of) itself, the import declaration will relate to the package in __node_modules__.

Using a relative import specifier *always* works, and has the added benefit of not being a Node-specific feature.


[1]: https://nodejs.org/api/packages.html#exports
